### PR TITLE
Add maximum deadheading distance check

### DIFF
--- a/blocks_to_transfers/config.py
+++ b/blocks_to_transfers/config.py
@@ -3,6 +3,12 @@ class TripToTripTransfers:
     # Maximum layover between a trip and its continuation
     max_wait_time = 1200  # seconds
 
+    # Maximum speed of travel between last stop of trip and first stop of its continuation
+    max_deadheading_speed = 50  # km/h
+
+    # At smaller deadheading distances, speed will be ignored
+    max_nearby_deadheading_distance = 500  # m
+
     # If a block is invalid because it cannot be operated using a single vehicle, because a later trip departs before
     # the previous trip has completed, should the algorithm still attempt to find a plausible continuation trip?
     force_allow_invalid_blocks = False

--- a/blocks_to_transfers/convert_blocks.py
+++ b/blocks_to_transfers/convert_blocks.py
@@ -181,7 +181,7 @@ def consider_transfer(data, trip_state, cont_trip):
                     _rank=trip_state.num_matches)
 
 
-KM_H_FACTOR = 3.6
+KM_H_FACTOR = 3.6  # Conversion factor between m/s and km/h
 
 
 def reasonable_deadheading_speed(trip, cont_trip, wait_time, debug_context):

--- a/blocks_to_transfers/convert_blocks.py
+++ b/blocks_to_transfers/convert_blocks.py
@@ -4,6 +4,7 @@ For every trip within a block, identifies valid continuation trips on each day o
 from collections import namedtuple
 from .editor.schema import Transfer, DAY_SEC
 from . import config, service_days
+import math
 
 BlockConvertState = namedtuple('BlockConvertState',
                                ('gtfs', 'services', 'shape_similarity_results'))
@@ -106,11 +107,11 @@ def convert_block(data, trips):
 
 class InvalidBlockError(ValueError):
 
-    def __init__(self, trip, cont_trip, debug):
+    def __init__(self, trip, cont_trip, debug_context):
         super().__init__(self, 'Invalid block')
         self.trip = trip
         self.cont_trip = cont_trip
-        self.debug = debug
+        self.debug_context = debug_context
 
     def __str__(self):
         wait_time = self.cont_trip.first_departure - self.trip.last_arrival
@@ -120,7 +121,7 @@ class InvalidBlockError(ValueError):
         Warning: Block {block_id} is invalid:
                 {self.trip.first_departure} - {self.trip.last_arrival} [{self.trip.trip_id}]
                 {self.cont_trip.first_departure} - {self.cont_trip.last_arrival} [{self.cont_trip.trip_id}]
-                In two places at once for {abs(wait_time)} s on days {self.debug}.
+                In two places at once for {abs(wait_time)} s on days {self.debug_context}.
         '''
 
 
@@ -153,11 +154,23 @@ def consider_transfer(data, trip_state, cont_trip):
     # We know that trip and cont_trip operate together on at least one day, and yet there's no way a single
     # vehicle can do this.
     if wait_time < 0:
+        block_error = InvalidBlockError(
+            trip_state.trip,
+            cont_trip,
+            debug_context=data.services.pdates(days_when_best))
+
         if config.TripToTripTransfers.force_allow_invalid_blocks:
+            print(block_error)
             return None
         else:
-            debug = data.services.bdates(days_when_best)
-            raise InvalidBlockError(trip_state.trip, cont_trip, debug)
+            raise block_error
+
+    if not reasonable_deadheading_speed(
+            trip_state.trip,
+            cont_trip,
+            wait_time,
+            debug_context=data.services.pdates(days_when_best)):
+        return None
 
     trip_state.days_to_match = trip_state.days_to_match.difference(
         days_when_best)
@@ -166,3 +179,25 @@ def consider_transfer(data, trip_state, cont_trip):
     return Transfer(from_trip_id=trip_state.trip.trip_id,
                     to_trip_id=cont_trip.trip_id,
                     _rank=trip_state.num_matches)
+
+
+KM_H_FACTOR = 3.6
+
+
+def reasonable_deadheading_speed(trip, cont_trip, wait_time, debug_context):
+    dist = trip.last_point.distance_to(cont_trip.first_point)
+    if dist < config.TripToTripTransfers.max_nearby_deadheading_distance:
+        return True
+
+    speed = KM_H_FACTOR * dist / wait_time if wait_time else math.inf
+
+    if speed > config.TripToTripTransfers.max_deadheading_speed:
+        print(f'''
+        Warning: Block {trip.block_id} is invalid:
+                {trip.first_departure} - {trip.last_stop_time.stop.stop_name} @ {trip.last_arrival} [{trip.trip_id}]
+                {cont_trip.first_stop_time.stop.stop_name} @ {cont_trip.first_departure} - {cont_trip.last_arrival} [{cont_trip.trip_id}]
+                Would require travelling {dist/1000:.2f} km at {speed:.0f} km/h on days {debug_context}.
+        ''')
+        return False
+
+    return True

--- a/blocks_to_transfers/editor/schema.py
+++ b/blocks_to_transfers/editor/schema.py
@@ -146,6 +146,10 @@ class StopTime(Entity):
     arrival_time: GTFSTime = GTFSTime('')
     departure_time: GTFSTime = GTFSTime('')
 
+    @property
+    def stop(self):
+        return self._gtfs.stops[self.stop_id]
+
 
 GTFS_SUBSET_SCHEMA = Schema(Calendar, CalendarDate, Trip, Stop, Transfer,
                             StopTime)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='GTFS-blocks-to-transfers',
-      version='1.1.0',
+      version='1.2.0',
       description='Convert GTFS blocks to trip-to-trip transfers',
       url='https://github.com/TransitApp/GTFS-blocks-to-transfers',
       author='Nicholas Paun',


### PR DESCRIPTION
[This PR is part of our work at Transit to use this tool to process feeds that contain some blocks that are invalid.]

Consider the block below:

| Trip       | Origin | Time | Destination | Time |
|--------|-------|-------|-------------|------|
| 1 | Vancouver | 12:24 | Surrey  | 13:04 |
| 2 | Vancouver | 13:06 | Surrey  | 13:41 |

While the two trips do not overlap in time,  it is apparent that they have been mistakenly combined into one block, as the distance between the two cities could not possibly be covered in 2 minutes using means of transportation currently known to man.

Data issues like these are common, but unfortunately they're not always as clear cut, as there is a large variability in the speed at which routes can be operated. This PR introduces the following two heuristics:

* `max_nearby_deadheading_distance`: If the distance between the two stops is less than 500 m, then it is automatically allowed. This covers trips that continue from the exact same stop, from the equivalent stop on the other side of the road, and other ordinary situations
* `max_deadheading_speed`: Longer distances will be allowed if they represent deadheading, where the vehicle is moved to another location, before starting the next trip. The maximum allowed speed is 50 km/h, based on the _straight-line distance_ between the two stops. 