### PR TITLE
Standardize emission of warnings

### DIFF
--- a/blocks_to_transfers/__main__.py
+++ b/blocks_to_transfers/__main__.py
@@ -2,7 +2,8 @@ import argparse
 import os
 import shutil
 import json
-from . import convert_blocks, config, editor, service_days, classify_transfers, simplify_graph, simplify_linear, simplify_export
+import sys
+from . import convert_blocks, config, editor, service_days, classify_transfers, simplify_graph, simplify_linear, simplify_export, logs
 
 
 def process(in_dir,
@@ -36,6 +37,7 @@ def apply_config(config_override_str):
         for k, v in options.items():
             setattr(config.__dict__[section], k, v)
 
+
 def main():
     cmd = argparse.ArgumentParser(
         description=
@@ -50,9 +52,11 @@ def main():
         '--remove-existing-files',
         action='store_true',
         help='Remove all files in the output directory before expoting')
-    cmd.add_argument('-c', '--config', 
-            default='{}',
-            help='Set config overrides in JSON (see config.py for options)')
+    cmd.add_argument(
+        '-c',
+        '--config',
+        default='{}',
+        help='Set config overrides in JSON (see config.py for options)')
     args = cmd.parse_args()
 
     if os.environ.get('VSCODE_DEBUG'):
@@ -66,6 +70,9 @@ def main():
             args.out_dir,
             use_simplify_linear=args.linear,
             remove_existing_files=args.remove_existing_files)
+
+    if logs.Warn.any_warnings:
+        sys.exit(2)
 
 
 if __name__ == '__main__':

--- a/blocks_to_transfers/logs.py
+++ b/blocks_to_transfers/logs.py
@@ -1,0 +1,30 @@
+"""
+Handles the printing of warnings generated during processing.
+"""
+
+import textwrap
+import sys
+
+
+class Warn(Exception):
+    N_INDENT = 4
+    any_warnings = False
+
+    def __init__(self, raw_message):
+        Warn.any_warnings = True
+
+        # Force standard formatting for message
+        lines = raw_message.replace(Warn.N_INDENT * ' ',
+                                    '').strip().splitlines()
+        message = [f'Warning: {lines[0]}']
+        message.extend(Warn.indent(line) for line in lines[1:])
+        message.append('')
+
+        super().__init__('\n'.join(message))
+
+    @staticmethod
+    def indent(text, level=1):
+        return Warn.N_INDENT * level * ' ' + text
+
+    def print(self):
+        print(str(self), file=sys.stderr)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -35,11 +35,13 @@ def check_file(expected_filename, actual_filename):
 def test_standard(feed_dir):
     do_test(feed_dir, 'standard')
 
+
 @pytest.mark.parametrize('feed_dir',
                          find_tests('linear'),
                          ids=lambda test_dir: test_dir.name)
 def test_linear(feed_dir):
     do_test(feed_dir, 'linear')
+
 
 def do_test(feed_dir, simplification):
     work_dir = Path(tempfile.mkdtemp(prefix='', dir=WORK_DIR))


### PR DESCRIPTION
Warnings now appear similar in style when printed, will be sent to stderr, and if any warnings are raised the exit code will be 2. This helps with integrating this tool into a larger system that can pass on these warnings