### PR TITLE
Add trip columns to existing transfers.txt; avoid unneeded trip renames

### DIFF
--- a/blocks_to_transfers/config.py
+++ b/blocks_to_transfers/config.py
@@ -27,7 +27,7 @@ class InSeatTransfers:
     # Used to:
     #   - Discard in-seat transfers where the last stop of previous trip and first stop of ensuing trip are further apart than this distance
     #   - Calculate whether or not a trip is a return trip of the previous trip
-    same_location_distance = 100  # meters
+    same_location_distance = 500  # meters
 
     # If true, ignore all trips serving the same route in the opposite direction
     ignore_return_via_same_route = False

--- a/blocks_to_transfers/editor/__init__.py
+++ b/blocks_to_transfers/editor/__init__.py
@@ -59,6 +59,8 @@ def merge_header_and_declared_fields(file_schema, header_row):
             raise ValueError(
                 f'{file_schema.filename}:1: missing required field {name}')
 
+        fields.setdefault(name, config)
+
     return fields
 
 

--- a/blocks_to_transfers/simplify_export.py
+++ b/blocks_to_transfers/simplify_export.py
@@ -75,15 +75,16 @@ def split_noncontinuation_transfers(gtfs, trip_id_splits, transfers):
 
 
 def make_trip(graph, trip_id_splits, node):
-    service_id = graph.services.get_or_assign(node.trip, node.days)
     splits = trip_id_splits.setdefault(node.trip_id, set())
 
-    if node.trip.service_id == service_id:
-        # If the service_id did not change, avoid cloning the trip to minimize diffs
+    trip_original_days = graph.services.days_by_service[node.trip.service_id]
+    if trip_original_days == node.days:
+        # If the days of service did not change, avoid cloning the trip to minimize diffs
         splits.add(node.trip_id)
         return node.trip_id
 
     # Other trips are named according to a standard form
+    service_id = graph.services.get_or_assign(node.trip, node.days)
     split_trip_id = f'{node.trip_id}_b2t:if_{service_id}'
     if split_trip_id not in graph.gtfs.trips:
         editor.clone(graph.gtfs.trips, node.trip_id, split_trip_id)

--- a/blocks_to_transfers/simplify_export.py
+++ b/blocks_to_transfers/simplify_export.py
@@ -77,7 +77,7 @@ def split_noncontinuation_transfers(gtfs, trip_id_splits, transfers):
 def make_trip(graph, trip_id_splits, node):
     splits = trip_id_splits.setdefault(node.trip_id, set())
 
-    trip_original_days = graph.services.days_by_service[node.trip.service_id]
+    trip_original_days = graph.services.days_by_trip(node.trip)
     if trip_original_days == node.days:
         # If the days of service did not change, avoid cloning the trip to minimize diffs
         splits.add(node.trip_id)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='GTFS-blocks-to-transfers',
-      version='1.2.0',
+      version='1.2.1',
       description='Convert GTFS blocks to trip-to-trip transfers',
       url='https://github.com/TransitApp/GTFS-blocks-to-transfers',
       author='Nicholas Paun',


### PR DESCRIPTION
This fixes a couple bugs when merging generated trip-to-trip transfers back into existing feeds.

* If a feed has an existing `transfers.txt`, but without `from_trip_id`, and `to_trip_id`, ensure these columns will be added in the output.
* When exporting transfers, we split and rename trips whose days of service have changed as a result of continuation processing. However, if the days of service haven't changed, we avoid unnecessary modifications. Previously the check was done based on the service_id string, which could end up arbitrarily swapping between different services that represent the same days of service. This doesn't affect the accuracy of the results, but made them harder to read.