### PR TITLE
Improve error messages

### DIFF
--- a/blocks_to_transfers/__main__.py
+++ b/blocks_to_transfers/__main__.py
@@ -66,10 +66,15 @@ def main():
         debugpy.wait_for_client()
 
     apply_config(args.config)
-    process(args.feed,
-            args.out_dir,
-            use_simplify_linear=args.linear,
-            remove_existing_files=args.remove_existing_files)
+    try:
+        process(args.feed,
+                args.out_dir,
+                use_simplify_linear=args.linear,
+                remove_existing_files=args.remove_existing_files)
+    except editor.ParseError as exc:
+        # Skip backtrace for common issues with the input GTFS feed
+        print('ParseError', exc)
+        sys.exit(1)
 
     if logs.Warn.any_warnings:
         sys.exit(2)

--- a/blocks_to_transfers/convert_blocks.py
+++ b/blocks_to_transfers/convert_blocks.py
@@ -135,10 +135,11 @@ def consider_transfer(data, trip_state, cont_trip):
     # vehicle can do this.
     if wait_time < 0:
         debug_context = data.services.pdates(days_when_best)
+        action = 'attempting auto-fix' if config.TripToTripTransfers.force_allow_invalid_blocks else 'deleted'
         block_error = Warn(f'''
-        Block {trip_state.trip.block_id} is invalid:
-                {trip_state.trip.first_departure} - {trip_state.trip.last_arrival} [{trip_state.trip.trip_id}]
-                {cont_trip.first_departure} - {cont_trip.last_arrival} [{cont_trip.trip_id}]
+        Block {trip_state.trip.block_id} is invalid - {action}:
+                {trip_state.trip.first_departure} -> {trip_state.trip.last_arrival} [trip {trip_state.trip.trip_id}]
+                {cont_trip.first_departure} -> {cont_trip.last_arrival} [trip {cont_trip.trip_id}]
                 In two places at once for {abs(wait_time)} s on days {debug_context}.
         ''')
 
@@ -176,9 +177,9 @@ def reasonable_deadheading_speed(trip, cont_trip, wait_time, debug_context):
 
     if speed > config.TripToTripTransfers.max_deadheading_speed:
         Warn(f'''
-        Block {trip.block_id} is invalid:
-                {trip.first_departure} - {trip.last_stop_time.stop.stop_name} @ {trip.last_arrival} [{trip.trip_id}]
-                {cont_trip.first_stop_time.stop.stop_name} @ {cont_trip.first_departure} - {cont_trip.last_arrival} [{cont_trip.trip_id}]
+        Block {trip.block_id} is invalid - attempting auto-fix:
+                {trip.first_stop_time.stop.stop_name} @ {trip.first_departure} -> {trip.last_stop_time.stop.stop_name} @ {trip.last_arrival} [trip {trip.trip_id}]
+                {cont_trip.first_stop_time.stop.stop_name} @ {cont_trip.first_departure} -> {trip.last_stop_time.stop.stop_name} @ {cont_trip.last_arrival} [trip {cont_trip.trip_id}]
                 Would require travelling {dist/1000:.2f} km at {speed:.0f} km/h on days {debug_context}.
         ''').print()
         return False

--- a/blocks_to_transfers/convert_blocks.py
+++ b/blocks_to_transfers/convert_blocks.py
@@ -133,21 +133,11 @@ def consider_transfer(data, trip_state, cont_trip):
 
     # We know that trip and cont_trip operate together on at least one day, and yet there's no way a single
     # vehicle can do this.
-    if wait_time < 0:
-        debug_context = data.services.pdates(days_when_best)
-        action = 'attempting auto-fix' if config.TripToTripTransfers.force_allow_invalid_blocks else 'deleted'
-        block_error = Warn(f'''
-        Block {trip_state.trip.block_id} is invalid - {action}:
-                {trip_state.trip.first_departure} -> {trip_state.trip.last_arrival} [trip {trip_state.trip.trip_id}]
-                {cont_trip.first_departure} -> {cont_trip.last_arrival} [trip {cont_trip.trip_id}]
-                In two places at once for {abs(wait_time)} s on days {debug_context}.
-        ''')
-
-        if config.TripToTripTransfers.force_allow_invalid_blocks:
-            block_error.print()
-            return None
-        else:
-            raise block_error
+    if not valid_wait_time(trip_state.trip,
+                           cont_trip,
+                           wait_time,
+                           debug_context=data.services.pdates(days_when_best)):
+        return None
 
     if not reasonable_deadheading_speed(
             trip_state.trip,
@@ -178,10 +168,39 @@ def reasonable_deadheading_speed(trip, cont_trip, wait_time, debug_context):
     if speed > config.TripToTripTransfers.max_deadheading_speed:
         Warn(f'''
         Block {trip.block_id} is invalid - attempting auto-fix:
-                {trip.first_stop_time.stop.stop_name} @ {trip.first_departure} -> {trip.last_stop_time.stop.stop_name} @ {trip.last_arrival} [trip {trip.trip_id}]
-                {cont_trip.first_stop_time.stop.stop_name} @ {cont_trip.first_departure} -> {trip.last_stop_time.stop.stop_name} @ {cont_trip.last_arrival} [trip {cont_trip.trip_id}]
-                Would require travelling {dist/1000:.2f} km at {speed:.0f} km/h on days {debug_context}.
+            | {trip.first_departure} {trip.first_stop_time.stop.stop_name} [trip {trip.trip_id}]
+            v {trip.last_arrival} {trip.last_stop_time.stop.stop_name} [trip {trip.trip_id}]
+                (!) Would require travelling {dist/1000:.2f} km at {speed:.0f} km/h (!)
+            | {cont_trip.first_departure} {cont_trip.first_stop_time.stop.stop_name} [trip {cont_trip.trip_id}] 
+            v {cont_trip.last_arrival} {cont_trip.last_stop_time.stop.stop_name} [trip {cont_trip.trip_id}]
+            
+            Occurs on days {debug_context}.
         ''').print()
         return False
 
     return True
+
+
+def valid_wait_time(trip, cont_trip, wait_time, debug_context):
+
+    def trip_desc(char, trip, time):
+        return f'{char} {time} [trip {trip.trip_id}]'
+
+    if wait_time >= 0:
+        return True
+
+    action = 'attempting auto-fix' if config.TripToTripTransfers.force_allow_invalid_blocks else 'deleted'
+    block_error = Warn(f'''
+        Block {trip.block_id} is invalid - {action}:
+            {trip_desc('|', trip, trip.first_departure):<60}\t\t{trip_desc('|', cont_trip, cont_trip.first_departure):<60} 
+            {trip_desc('v', trip, trip.last_arrival):<60}\t\t{trip_desc('v', cont_trip, cont_trip.last_arrival):<60}
+            \t\t(!) In two places at once for {abs(wait_time)} s (!)
+
+            Occurs on days {debug_context}.
+    ''')
+
+    if config.TripToTripTransfers.force_allow_invalid_blocks:
+        block_error.print()
+        return False
+    else:
+        raise block_error

--- a/blocks_to_transfers/convert_blocks.py
+++ b/blocks_to_transfers/convert_blocks.py
@@ -170,7 +170,7 @@ def reasonable_deadheading_speed(trip, cont_trip, wait_time, debug_context):
         Block {trip.block_id} is invalid - attempting auto-fix:
             | {trip.first_departure} {trip.first_stop_time.stop.stop_name} [trip {trip.trip_id}]
             v {trip.last_arrival} {trip.last_stop_time.stop.stop_name} [trip {trip.trip_id}]
-                (!) Would require travelling {dist/1000:.2f} km at {speed:.0f} km/h (!)
+            \t(!) Would require travelling {dist/1000:.2f} km at {speed:.0f} km/h (!)
             | {cont_trip.first_departure} {cont_trip.first_stop_time.stop.stop_name} [trip {cont_trip.trip_id}] 
             v {cont_trip.last_arrival} {cont_trip.last_stop_time.stop.stop_name} [trip {cont_trip.trip_id}]
             

--- a/blocks_to_transfers/editor/__init__.py
+++ b/blocks_to_transfers/editor/__init__.py
@@ -80,7 +80,7 @@ def parse_rows(gtfs, file_schema, fields, header_row, reader):
                 config,
                 value,
                 context_fn=lambda:
-                f'{file_schema}:{lineno} field {name} = {repr(value)}')
+                f'{file_schema.filename}:{lineno} field {name} = {repr(value)}')
 
         yield entity
 
@@ -89,7 +89,7 @@ def validate(config, value, context_fn):
     try:
         return convert(config, value)
     except Exception as exc:
-        raise ValueError(f'{context_fn()}: {exc.args[0]}')
+        raise ValueError(f'{context_fn()}: {exc.args[0]}') from None
 
 
 def convert(config, value):

--- a/blocks_to_transfers/editor/__init__.py
+++ b/blocks_to_transfers/editor/__init__.py
@@ -5,6 +5,10 @@ from pathlib import Path
 from . import schema_classes, types, schema
 
 
+class ParseError(ValueError):
+    pass
+
+
 def load(gtfs_dir):
     gtfs_dir = Path(gtfs_dir)
     gtfs = types.Entity()
@@ -16,7 +20,7 @@ def load(gtfs_dir):
 
         if not filepath.exists():
             if file_schema.required:
-                raise ValueError(
+                raise ParseError(
                     f'{file_schema.filename}: required file is missing')
             else:
                 continue
@@ -26,7 +30,7 @@ def load(gtfs_dir):
             header_row = next(reader, None)
             if not header_row:
                 if file_schema.required:
-                    raise ValueError(
+                    raise ParseError(
                         f'{file_schema.filename}: required file is empty')
                 else:
                     continue
@@ -56,7 +60,7 @@ def merge_header_and_declared_fields(file_schema, header_row):
 
     for name, config in declared_fields.items():
         if config.required and name not in fields:
-            raise ValueError(
+            raise ParseError(
                 f'{file_schema.filename}:1: missing required field {name}')
 
         fields.setdefault(name, config)
@@ -72,7 +76,7 @@ def parse_rows(gtfs, file_schema, fields, header_row, reader):
         for name, value in zip(header_row, row):
             config = fields[name]
             if config.required and not value:
-                raise ValueError(
+                raise ParseError(
                     f'{file_schema.filename}:{lineno}: required field {name} is empty'
                 )
 
@@ -89,7 +93,7 @@ def validate(config, value, context_fn):
     try:
         return convert(config, value)
     except Exception as exc:
-        raise ValueError(f'{context_fn()}: {exc.args[0]}') from None
+        raise ParseError(f'{context_fn()}: {exc.args[0]}') from None
 
 
 def convert(config, value):

--- a/blocks_to_transfers/service_days.py
+++ b/blocks_to_transfers/service_days.py
@@ -170,7 +170,7 @@ class ServiceDays:
 
 
 def pdates(dates):
-    sdates = sorted(date.strftime('%m%d') for date in dates)
+    sdates = sorted(date.strftime('%m-%d') for date in dates)
     tdates = ', '.join(sdates[:14])
     if len(dates) > 14:
         tdates += ' ...'

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='GTFS-blocks-to-transfers',
-      version='1.2.1',
+      version='1.2.2',
       description='Convert GTFS blocks to trip-to-trip transfers',
       url='https://github.com/TransitApp/GTFS-blocks-to-transfers',
       author='Nicholas Paun',


### PR DESCRIPTION
This PR improves the design of error messages for the most common issue in feeds. Small schematics, designed to illustrate the problem, has been added to the overlapping trips and excessively fast deadheading messages.

### Overlapping trips
```
Warning: Block a_2023797 is invalid - deleted:
    | 04:40:00 [trip 12963250]  		| 05:06:00 [trip 12966729]
    v 05:25:00 [trip 12963250]  		v 05:26:00 [trip 12966729]
    		(!) In two places at once for 1140 s (!)

    Occurs on days 02-21.
```

### Excessively fast deadheading
```
Warning: Block 25997 is invalid - attempting auto-fix:
    | 08:05:00 Portland Hills Terminal  Bay 1 [trip 19283586]
    v 08:47:00 Porters Lake Park & Ride [trip 19283586]
    	(!) Would require travelling 18.79 km at 66 km/h (!)
    | 09:04:00 Portland Hills Terminal  Bay 5 [trip 19281928]
    v 09:44:00 Commodore Dr / Countryview Dr [trip 19281928]

    Occurs on days 05-08, 05-15, 05-22.
```
