### PR TITLE
Add banned stop list feature

### DIFF
--- a/blocks_to_transfers/classify_transfers.py
+++ b/blocks_to_transfers/classify_transfers.py
@@ -40,6 +40,13 @@ def get_transfer_type(gtfs, shape_match, transfer):
     if wait_time > config.InSeatTransfers.max_wait_time:
         return TransferType.VEHICLE_CONTINUATION
 
+    # transfer involves a banned stop
+    if (trip.last_stop_time.stop.stop_name
+            in config.InSeatTransfers.banned_stops or
+            cont_trip.first_stop_time.stop.stop_name
+            in config.InSeatTransfers.banned_stops):
+        return TransferType.VEHICLE_CONTINUATION
+
     # cont_trip resumes too far away from where trip ended (probably involves deadheading)
     if trip.last_point.distance_to(
             cont_trip.first_point

--- a/blocks_to_transfers/config.py
+++ b/blocks_to_transfers/config.py
@@ -42,3 +42,8 @@ class InSeatTransfers:
     # The provided constants work best in urban areas, but are far from perfect even there.
     similarity_percentile = .8  # / 1.0
     similarity_distance = 100  # meters
+
+    # A list of stop names at which in-seat transfers are never permitted. At these locations, continuations will
+    # always be classified as vehicle continuation only (transfer_type=5)
+    banned_stops = []
+

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='GTFS-blocks-to-transfers',
-      version='1.2.2',
+      version='1.3.0',
       description='Convert GTFS blocks to trip-to-trip transfers',
       url='https://github.com/TransitApp/GTFS-blocks-to-transfers',
       author='Nicholas Paun',


### PR DESCRIPTION
One common feature request we have received both from agencies and from internal users at Transit, is to have a list of banned stops, where in-seat transfers are not possible. Continuations detected at those locations will always be marked as vehicle continuation only.

This situation often occurs at large transit centres, where all riders are expected to disembark. Examples: [Rochester, NY](https://www.myrts.com/Portals/0/Documents/RTS-transit-center-map.pdf), [Longueuil, QC](https://www.rtl-longueuil.qc.ca/CMS/MediaFree/file/RTL/Plan-Terminus-Stationnement/Plan-terminus%20longueuil-%20aout%202021.pdf)

Stops will be identified by `stop_name` for stability, as the `stop_id` value changes often in many agency systems.