### PR TITLE
Fix: Accept generic nodes without locations

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: [ubuntu-latest]
     strategy:
       matrix:
-        python-version: [pypy-3.7]
+        python-version: [pypy-3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/blocks_to_transfers/config.py
+++ b/blocks_to_transfers/config.py
@@ -46,4 +46,3 @@ class InSeatTransfers:
     # A list of stop names at which in-seat transfers are never permitted. At these locations, continuations will
     # always be classified as vehicle continuation only (transfer_type=5)
     banned_stops = []
-

--- a/blocks_to_transfers/convert_blocks.py
+++ b/blocks_to_transfers/convert_blocks.py
@@ -22,7 +22,6 @@ class TripConvertState:
 
 def convert(gtfs, services):
     print('Predicting continuation trip for trips within blocks')
-
     trips_by_block = group_trips(gtfs)
     converted_transfers = []
     data = BlockConvertState(gtfs, services, {})

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='GTFS-blocks-to-transfers',
-      version='1.3.0',
+      version='1.3.1',
       description='Convert GTFS blocks to trip-to-trip transfers',
       url='https://github.com/TransitApp/GTFS-blocks-to-transfers',
       author='Nicholas Paun',


### PR DESCRIPTION
This PR fixes a small issue encountered while testing the tool on the MBTA feed.

In order to apply heuristics, the converter tool requires the coordinates of each routable stop (`location_type=0`) . However other types of stops, like generic nodes, aren't required to provide the fields `stop_lat` and `stop_lon`. See the definition of [stops.txt](https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#stopstxt) in the GTFS spec. Although such stops aren't used in the conversion process, the tool must correctly load and ignore these rows. 

Additionally, I've done some small refactoring to use Python 3.8 features to reduce some verbosity.