### PR TITLE
Adding a python-friendly API to perform processing

### DIFF
--- a/blocks_to_transfers/__init__.py
+++ b/blocks_to_transfers/__init__.py
@@ -1,0 +1,15 @@
+# Exposing the core API to allow using via python-code (not just via CLI)
+
+from . import processing, runtime_config
+
+def process_with_config(in_dir,
+            out_dir,
+            config_override,
+            use_simplify_linear=False,
+            remove_existing_files=False,
+            sorted_io=False,
+            ):
+    runtime_config.apply(config_override)
+    processing.process(in_dir, out_dir, use_simplify_linear, remove_existing_files, sorted_io)
+
+__all__ = ["process_with_config"]

--- a/blocks_to_transfers/__main__.py
+++ b/blocks_to_transfers/__main__.py
@@ -1,41 +1,9 @@
 import argparse
 import os
-import shutil
 import json
 import sys
 import gtfs_loader
-from . import convert_blocks, config, service_days, classify_transfers, simplify_fix, simplify_linear, simplify_export, logs, runtime_config, set_pickup_drop_off
-
-
-def process(in_dir,
-            out_dir,
-            use_simplify_linear=False,
-            remove_existing_files=False,
-            sorted_io=False,
-            ):
-    gtfs = gtfs_loader.load(in_dir, sorted_read=sorted_io)
-
-    services = service_days.ServiceDays(gtfs)
-    converted_transfers = convert_blocks.convert(gtfs, services)
-    classify_transfers.classify(gtfs, converted_transfers)
-
-    graph = simplify_fix.simplify(gtfs, services, converted_transfers)
-
-    if use_simplify_linear:
-        output_graph = simplify_linear.simplify(graph)
-    else:
-        output_graph = graph
-    simplify_export.export_visit(output_graph)
-
-    set_pickup_drop_off.set_pickup_drop_off(gtfs)
-
-    if remove_existing_files:
-        shutil.rmtree(out_dir, ignore_errors=True)
-
-    gtfs_loader.patch(gtfs, gtfs_in_dir=in_dir, gtfs_out_dir=out_dir, 
-            sorted_output=sorted_io)
-    
-    print('Done.')
+from . import config, classify_transfers, logs, runtime_config, processing
 
 
 def main():
@@ -65,10 +33,10 @@ def main():
         debugpy.listen(5678)
         debugpy.wait_for_client()
 
-    runtime_config.apply(args.config)
+    runtime_config.apply(json.loads(args.config))
 
     try:
-        process(args.feed,
+        processing.process(args.feed,
                 args.out_dir,
                 use_simplify_linear=args.linear,
                 remove_existing_files=args.remove_existing_files)

--- a/blocks_to_transfers/processing.py
+++ b/blocks_to_transfers/processing.py
@@ -1,0 +1,34 @@
+import gtfs_loader
+import shutil
+from . import convert_blocks, service_days, classify_transfers, simplify_fix, simplify_linear, simplify_export, set_pickup_drop_off
+
+
+def process(in_dir,
+            out_dir,
+            use_simplify_linear=False,
+            remove_existing_files=False,
+            sorted_io=False,
+            ):
+    gtfs = gtfs_loader.load(in_dir, sorted_read=sorted_io)
+
+    services = service_days.ServiceDays(gtfs)
+    converted_transfers = convert_blocks.convert(gtfs, services)
+    classify_transfers.classify(gtfs, converted_transfers)
+
+    graph = simplify_fix.simplify(gtfs, services, converted_transfers)
+
+    if use_simplify_linear:
+        output_graph = simplify_linear.simplify(graph)
+    else:
+        output_graph = graph
+    simplify_export.export_visit(output_graph)
+
+    set_pickup_drop_off.set_pickup_drop_off(gtfs)
+
+    if remove_existing_files:
+        shutil.rmtree(out_dir, ignore_errors=True)
+
+    gtfs_loader.patch(gtfs, gtfs_in_dir=in_dir, gtfs_out_dir=out_dir, 
+            sorted_output=sorted_io)
+    
+    print('Done.')

--- a/blocks_to_transfers/runtime_config.py
+++ b/blocks_to_transfers/runtime_config.py
@@ -2,12 +2,10 @@ import json
 from . import config
 
 
-def apply(config_override_str):
+def apply(config_override):
     """
-    Applies JSON configuration options passed at runtime
+    Applies configuration options passed at runtime
     """
-    config_override = json.loads(config_override_str)
-
     for section, options in config_override.items():
         if section == 'SpecialContinuations':
             # This section is a list


### PR DESCRIPTION
The current package-structure makes it difficult to use it via other python-code, as it was designed for the CLI.

My changes make it easier to use, allowing performing processing with specific configuration via a single function that is exported from the package at the top-level:
```py
from blocks_to_transfers import process_with_config

runtime_config = {
  "TripToTripTransfers": {
    "force_allow_invalid_blocks": True,
  },
  ...
}

process_with_config(
  '...',
  '...',
  runtime_config,
  use_simplify_linear=True, remove_existing_files=True, sorted_io=False
)
```

**Important**: The current CLI-API remains the same and functions exactly as it used to.